### PR TITLE
Use private attrs for sensitive config credentials

### DIFF
--- a/components/clp-package-utils/clp_package_utils/general.py
+++ b/components/clp-package-utils/clp_package_utils/general.py
@@ -353,7 +353,7 @@ def dump_container_config(
     config_file_path_on_host = clp_config.logs_directory / config_filename
     config_file_path_on_container = container_clp_config.logs_directory / config_filename
     with open(config_file_path_on_host, "w") as f:
-        yaml.safe_dump(container_clp_config.dump_to_primitive_dict(), f)
+        yaml.safe_dump(container_clp_config.model_dump(), f)
 
     return config_file_path_on_container, config_file_path_on_host
 


### PR DESCRIPTION
## Summary
- store the database, queue, and redis credentials in PrivateAttr-backed properties so they remain excluded from dumps while still being validated
- keep compatibility with configs that specify credentials by capturing the legacy fields during model initialization

## Testing
- task *(interrupted after extended dependency builds; manually stopped once downloads were verified)*
- ruff check components/clp-py-utils/clp_py_utils/clp_config.py

------
https://chatgpt.com/codex/tasks/task_e_68fcd99e1d3c8327b1efbbc3b750714a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal credential handling and validation for database, Redis, and queue configurations.
  * Enhanced configuration serialization to better manage sensitive credential fields during log operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->